### PR TITLE
#28 履歴一覧ページ作成

### DIFF
--- a/src/lib/components/HistoryTable.svelte
+++ b/src/lib/components/HistoryTable.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { formatDateJP } from '$lib/utils/date_format';
+
+	type HistoryEntry = {
+		id: number;
+		count: number;
+		clicked_at: string | Date;
+	};
+
+	type Props = {
+		history: HistoryEntry[];
+	};
+
+	let { history }: Props = $props();
+</script>
+
+<div class="overflow-x-auto rounded-lg border border-gray-200">
+	<table class="w-full text-left text-sm">
+		<thead class="bg-[#1B2A4A] text-white">
+			<tr>
+				<th class="px-6 py-3 font-medium">#</th>
+				<th class="px-6 py-3 font-medium">カウント</th>
+				<th class="px-6 py-3 font-medium">クリック日時</th>
+			</tr>
+		</thead>
+		<tbody>
+			{#each history as entry, i (entry.id)}
+				<tr class="border-t border-gray-100 transition hover:bg-gray-50">
+					<td class="px-6 py-3 text-gray-400">{i + 1}</td>
+					<td class="px-6 py-3 font-medium text-[#1B2A4A]">{entry.count}</td>
+					<td class="px-6 py-3 text-gray-500">{formatDateJP(entry.clicked_at)}</td>
+				</tr>
+			{:else}
+				<tr>
+					<td colspan="3" class="px-6 py-8 text-center text-gray-400"> No history yet. </td>
+				</tr>
+			{/each}
+		</tbody>
+	</table>
+</div>

--- a/src/lib/server/counter.ts
+++ b/src/lib/server/counter.ts
@@ -1,28 +1,28 @@
 import { db } from '$lib/server/db';
 
 interface CountHistory {
-    id: number;
-    counter_id: number;
-    count: number;
-    clicked_at: string;
+	id: number;
+	counter_id: number;
+	count: number;
+	clicked_at: string;
 }
 
 function toCountHistory(row: Record<string, unknown>): CountHistory {
-    if (
-        typeof row.id !== 'number' ||
-        typeof row.counter_id !== 'number' ||
-        typeof row.count !== 'number' ||
-        typeof row.clicked_at !== 'string'
-    ) {
-        throw new Error(`Invalid count_history row shape: ${JSON.stringify(row)}`);
-    }
+	if (
+		typeof row.id !== 'number' ||
+		typeof row.counter_id !== 'number' ||
+		typeof row.count !== 'number' ||
+		typeof row.clicked_at !== 'string'
+	) {
+		throw new Error(`Invalid count_history row shape: ${JSON.stringify(row)}`);
+	}
 
-    return {
-        id: row.id,
-        counter_id: row.counter_id,
-        count: row.count,
-        clicked_at: row.clicked_at,
-    };
+	return {
+		id: row.id,
+		counter_id: row.counter_id,
+		count: row.count,
+		clicked_at: row.clicked_at
+	};
 }
 
 export async function ensureCounterTable() {
@@ -58,13 +58,13 @@ export async function getCounter(): Promise<number> {
 }
 
 export async function incrementCounter(): Promise<number> {
-    await db.execute('UPDATE counters SET value = value + 1 WHERE id = 1');
-    const newValue = await getCounter();
-    await db.execute({
-        sql: 'INSERT INTO count_histories (counter_id, count) VALUES (?, ?)',
-        args: [1, newValue],
-    });
-    return newValue;
+	await db.execute('UPDATE counters SET value = value + 1 WHERE id = 1');
+	const newValue = await getCounter();
+	await db.execute({
+		sql: 'INSERT INTO count_histories (counter_id, count) VALUES (?, ?)',
+		args: [1, newValue]
+	});
+	return newValue;
 }
 
 export async function resetCounter(): Promise<number> {
@@ -73,6 +73,6 @@ export async function resetCounter(): Promise<number> {
 }
 
 export async function getCountHistory(): Promise<CountHistory[]> {
-    const result = await db.execute('SELECT * FROM count_histories ORDER BY clicked_at DESC');
-    return result.rows.map((row) => toCountHistory(row as Record<string, unknown>));
+	const result = await db.execute('SELECT * FROM count_histories ORDER BY clicked_at DESC');
+	return result.rows.map((row) => toCountHistory(row as Record<string, unknown>));
 }

--- a/src/lib/utils/date_format.ts
+++ b/src/lib/utils/date_format.ts
@@ -1,0 +1,20 @@
+export function formatDate(date: string | Date): string {
+	return new Intl.DateTimeFormat('en-US', {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit'
+	}).format(new Date(date));
+}
+
+export function formatDateJP(date: string | Date): string {
+	return new Intl.DateTimeFormat('ja-JP', {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit'
+	}).format(new Date(date));
+}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -3,7 +3,8 @@ import {
 	ensureCounterTable,
 	ensureCountHistoryTable,
 	getCounter,
-	incrementCounter
+	incrementCounter,
+	resetCounter
 } from '$lib/server/counter';
 
 export const load: PageServerLoad = async () => {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,5 +1,10 @@
 import type { PageServerLoad, Actions } from './$types';
-import { ensureCounterTable, ensureCountHistoryTable, getCounter, incrementCounter, resetCounter } from '$lib/server/counter';
+import {
+	ensureCounterTable,
+	ensureCountHistoryTable,
+	getCounter,
+	incrementCounter
+} from '$lib/server/counter';
 
 export const load: PageServerLoad = async () => {
 	await ensureCounterTable();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,18 +3,24 @@
 	import CountDisplay from '$lib/components/CountDisplay.svelte';
 	import ResetButton from '$lib/components/ResetButton.svelte';
 	import { enhance } from '$app/forms';
+	import { resolveRoute } from '$app/paths';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
 </script>
 
-<div class="flex min-h-dvh flex-col items-center bg-[#F3ECDF]">
-	<header class="w-full py-8 text-center sm:py-10">
-		<h1
-			class="bold mt-1 font-['Noto_Sans_JP'] text-2xl tracking-[0.2em] text-[#1B2A4A] sm:text-3xl sm:tracking-[0.3em]"
+<div class="flex min-h-screen flex-col items-center bg-[#F3ECDF]">
+	<header class="grid w-full grid-cols-3 items-center py-10">
+		<a
+			href={resolveRoute('/history')}
+			class="text-md justify-self-start pl-6 text-[#1B2A4A]/60 transition hover:text-[#1B2A4A]"
 		>
+			歴史
+		</a>
+		<h1 class="bold mt-1 font-['Noto_Sans_JP'] text-3xl tracking-[0.3em] text-[#1B2A4A]">
 			ボタン カウンター
 		</h1>
+		<span aria-hidden="true" />
 	</header>
 
 	<main class="flex w-full max-w-xl flex-1 items-center justify-center px-4 sm:px-6">

--- a/src/routes/history/+page.server.ts
+++ b/src/routes/history/+page.server.ts
@@ -1,0 +1,8 @@
+import type { PageServerLoad } from './$types';
+import { ensureCountHistoryTable, getCountHistory } from '$lib/server/counter';
+
+export const load: PageServerLoad = async () => {
+	await ensureCountHistoryTable();
+	const history = await getCountHistory();
+	return { history };
+};

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import type { PageProps } from './$types';
+	import { resolveRoute } from '$app/paths';
+	import HistoryTable from '$lib/components/HistoryTable.svelte';
+
+	let { data }: PageProps = $props();
+</script>
+
+<header class="grid w-full grid-cols-3 items-center py-10">
+	<a
+		href={resolveRoute('/')}
+		class="justify-self-start pl-6 text-sm text-[#1B2A4A]/60 transition hover:text-[#1B2A4A]"
+	>
+		← 後ろ
+	</a>
+	<h1
+		class="justify-self-center font-['Noto_Sans_JP'] text-3xl font-bold tracking-[0.3em] text-[#1B2A4A]"
+	>
+		履歴
+	</h1>
+	<span aria-hidden="true" />
+</header>
+
+<main class="mx-auto max-w-2xl px-4">
+	<HistoryTable history={data.history} />
+</main>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,24 @@
 		"binding": "ASSETS",
 		"directory": ".svelte-kit/cloudflare"
 	},
-	"workers_dev": true,
-	"preview_urls": true
+	"secrets": {
+		"required": ["TURSO_DATABASE_URL", "TURSO_AUTH_TOKEN"]
+	},
+	"observability": {
+		"enabled": false,
+		"head_sampling_rate": 1,
+		"logs": {
+		"enabled": true,
+		"head_sampling_rate": 1,
+		"persist": true,
+		"invocation_logs": true
+		},
+		"traces": {
+		"enabled": false,
+		"persist": true,
+		"head_sampling_rate": 1
+		}
+	},
+	"workers_dev": false,
+	"preview_urls": false
 }


### PR DESCRIPTION
#28 履歴一覧ページ作成
この履歴一覧ページは完了しました。

- /history のようなルートを新規作成
- count_history テーブルからデータを取得して一覧表示
- 日時順に並べて見やすく表示

ご確認をよろしくお願いいたします。