### PR TITLE
Counter UI - press animation, reset button, responsive layout

### DIFF
--- a/src/lib/components/CountButton.svelte
+++ b/src/lib/components/CountButton.svelte
@@ -1,19 +1,39 @@
 <script lang="ts">
+	import { play } from '$lib/motion';
+
 	let { label = 'クリック' }: { label?: string } = $props();
+
+	let wrapper: HTMLSpanElement | undefined;
+
+	function playPress() {
+		play(
+			wrapper,
+			[
+				{ transform: 'scale(1)' },
+				{ transform: 'scale(0.9)', offset: 0.3 },
+				{ transform: 'scale(1.06)', offset: 0.65 },
+				{ transform: 'scale(1)' }
+			],
+			{ duration: 260, easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)' }
+		);
+	}
 </script>
 
-<button
-	type="submit"
-	class="group relative h-24 w-24 -rotate-3 rounded-full
-	       bg-[#BE3144]
-	       shadow-[0_6px_0_0_#7A1F2B,0_10px_22px_rgba(0,0,0,0.35)]
-	       transition-all duration-100
-	       hover:-rotate-1
-	       active:translate-y-1.5 active:rotate-0 active:shadow-[0_0px_0_0_#7A1F2B,0_2px_6px_rgba(0,0,0,0.3)]"
->
-	<span
-		class="absolute inset-1.5 flex items-center justify-center rounded-full border-2 border-white/70"
+<span bind:this={wrapper} class="inline-block">
+	<button
+		type="submit"
+		onclick={playPress}
+		class="group relative h-20 w-20 -rotate-3 touch-manipulation rounded-full bg-[#BE3144] shadow-[0_6px_0_0_#7A1F2B,0_10px_22px_rgba(0,0,0,0.35)] transition-all
+	       duration-100
+	       select-none
+	       hover:-rotate-1 active:translate-y-1.5
+	       active:rotate-0
+	       active:shadow-[0_0px_0_0_#7A1F2B,0_2px_6px_rgba(0,0,0,0.3)] sm:h-24 sm:w-24"
 	>
-		<span class="font-['Noto_Sans_JP'] text-xl font-bold text-white">{label}</span>
-	</span>
-</button>
+		<span
+			class="absolute inset-1.5 flex items-center justify-center rounded-full border-2 border-white/70"
+		>
+			<span class="font-['Noto_Sans_JP'] text-lg font-bold text-white sm:text-xl">{label}</span>
+		</span>
+	</button>
+</span>

--- a/src/lib/components/CountDisplay.svelte
+++ b/src/lib/components/CountDisplay.svelte
@@ -1,9 +1,38 @@
 <script lang="ts">
+	import { play } from '$lib/motion';
+
 	let { count = 0 }: { count?: number } = $props();
+
+	let numberEl: HTMLSpanElement | undefined;
+	// Plain let, not $state - tracking it would re-trigger the effect below.
+	let previous: number | undefined;
+
+	$effect(() => {
+		const current = count;
+		const isFirstRender = previous === undefined;
+		previous = current;
+
+		// The number already on screen at mount shouldn't pop.
+		if (isFirstRender) return;
+
+		play(
+			numberEl,
+			[
+				{ transform: 'scale(1)' },
+				{ transform: 'scale(1.18)', offset: 0.4 },
+				{ transform: 'scale(1)' }
+			],
+			{ duration: 220, easing: 'ease-out' }
+		);
+	});
 </script>
 
 <div class="flex flex-col items-center gap-1">
-	<span class="text-8xl font-extrabold text-slate-600 tabular-nums">
+	<!-- inline-block: transforms have no effect on inline elements -->
+	<span
+		bind:this={numberEl}
+		class="inline-block text-7xl font-extrabold text-slate-600 tabular-nums sm:text-8xl"
+	>
 		{count}
 	</span>
 	<span class="text-xs font-medium tracking-widest text-slate-400 uppercase">カウント</span>

--- a/src/lib/components/ResetButton.svelte
+++ b/src/lib/components/ResetButton.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+
+	let dialog: HTMLDialogElement | undefined;
+</script>
+
+<button
+	type="button"
+	onclick={() => dialog?.showModal()}
+	class="touch-manipulation rounded-lg border border-[#BE3144]/50 bg-[#FDF4F2] px-5 py-2 font-['Noto_Sans_JP'] text-xs font-bold tracking-[0.2em] text-[#BE3144] transition-colors duration-150 hover:bg-[#BE3144]/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#BE3144] sm:px-6 sm:text-sm"
+>
+	リセット
+</button>
+
+<dialog
+	bind:this={dialog}
+	onclick={(event) => {
+		if (event.target === dialog) dialog?.close();
+	}}
+	class="m-auto w-[calc(100vw-2rem)] max-w-sm rounded-2xl border border-[#C9A227]/40 bg-white p-6 shadow-2xl backdrop:bg-black/40 sm:p-8"
+>
+	<p class="font-['Noto_Sans_JP'] text-sm text-[#1B2A4A] sm:text-base">
+		カウントを 0 に戻しますか？
+	</p>
+
+	<div class="mt-6 flex justify-end gap-3">
+		<button
+			type="button"
+			onclick={() => dialog?.close()}
+			class="rounded-lg px-5 py-2 font-['Noto_Sans_JP'] text-sm text-[#1B2A4A]/70 transition-colors duration-150 hover:bg-black/5"
+		>
+			キャンセル
+		</button>
+
+		<form
+			method="POST"
+			action="?/reset"
+			use:enhance={() => {
+				// Dismiss straight away; enhance still applies the result.
+				dialog?.close();
+			}}
+		>
+			<button
+				type="submit"
+				class="rounded-lg bg-[#BE3144] px-5 py-2 font-['Noto_Sans_JP'] text-sm font-bold text-white transition-colors duration-150 hover:bg-[#A32739]"
+			>
+				リセット
+			</button>
+		</form>
+	</div>
+</dialog>

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,20 @@
+/**
+ * Small motion helpers shared by the counter UI.
+ */
+
+function prefersReducedMotion(): boolean {
+	return (
+		typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+	);
+}
+
+export function play(
+	element: HTMLElement | undefined,
+	keyframes: Keyframe[],
+	options: KeyframeAnimationOptions
+): void {
+	if (!element || prefersReducedMotion()) return;
+
+	for (const animation of element.getAnimations()) animation.cancel();
+	element.animate(keyframes, options);
+}

--- a/src/lib/server/counter.ts
+++ b/src/lib/server/counter.ts
@@ -67,6 +67,11 @@ export async function incrementCounter(): Promise<number> {
     return newValue;
 }
 
+export async function resetCounter(): Promise<number> {
+	await db.execute('UPDATE counters SET value = 0 WHERE id = 1');
+	return getCounter();
+}
+
 export async function getCountHistory(): Promise<CountHistory[]> {
     const result = await db.execute('SELECT * FROM count_histories ORDER BY clicked_at DESC');
     return result.rows.map((row) => toCountHistory(row as Record<string, unknown>));

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad, Actions } from './$types';
-import { ensureCounterTable, ensureCountHistoryTable, getCounter, incrementCounter } from '$lib/server/counter';
+import { ensureCounterTable, ensureCountHistoryTable, getCounter, incrementCounter, resetCounter } from '$lib/server/counter';
 
 export const load: PageServerLoad = async () => {
 	await ensureCounterTable();
@@ -10,6 +10,10 @@ export const load: PageServerLoad = async () => {
 export const actions: Actions = {
 	increment: async () => {
 		const count = await incrementCounter();
+		return { count };
+	},
+	reset: async () => {
+		const count = await resetCounter();
 		return { count };
 	}
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,29 +1,36 @@
 <script lang="ts">
 	import CountButton from '$lib/components/CountButton.svelte';
 	import CountDisplay from '$lib/components/CountDisplay.svelte';
+	import ResetButton from '$lib/components/ResetButton.svelte';
 	import { enhance } from '$app/forms';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
 </script>
 
-<div class="flex min-h-screen flex-col items-center bg-[#F3ECDF]">
-	<header class="w-full py-10 text-center">
-		<h1 class="bold mt-1 font-['Noto_Sans_JP'] text-3xl tracking-[0.3em] text-[#1B2A4A]">
+<div class="flex min-h-dvh flex-col items-center bg-[#F3ECDF]">
+	<header class="w-full py-8 text-center sm:py-10">
+		<h1
+			class="bold mt-1 font-['Noto_Sans_JP'] text-2xl tracking-[0.2em] text-[#1B2A4A] sm:text-3xl sm:tracking-[0.3em]"
+		>
 			ボタン カウンター
 		</h1>
 	</header>
 
-	<main class="flex w-full max-w-xl flex-1 items-center justify-center px-6">
+	<main class="flex w-full max-w-xl flex-1 items-center justify-center px-4 sm:px-6">
 		<div
-			class="relative flex w-full flex-col items-center gap-10 rounded-2xl border border-[#C9A227]/40 bg-white p-16 pl-20 shadow-2xl shadow-[#C9A227]/30"
+			class="relative flex w-full flex-col items-center gap-8 rounded-2xl border border-[#C9A227]/40 bg-white p-8 shadow-2xl shadow-[#C9A227]/30 sm:gap-10 sm:p-12 md:p-16"
 		>
 			<CountDisplay count={data.count} />
-			<form method="POST" action="?/increment" use:enhance>
-				<CountButton />
-			</form>
+			<div class="flex flex-col items-center gap-5 sm:gap-6">
+				<form method="POST" action="?/increment" use:enhance>
+					<CountButton />
+				</form>
+				<ResetButton />
+			</div>
 
-			<span class="font-['Noto_Sans_JP'] text-[10px] tracking-[0.3em] text-[#C9A227]/70"
+			<span
+				class="text-center font-['Noto_Sans_JP'] text-[10px] tracking-[0.2em] text-[#C9A227]/70 sm:tracking-[0.3em]"
 				>ボタンをクリックして下さい</span
 			>
 		</div>


### PR DESCRIPTION
UI work for the counter: press animation, reset button, mobile layout.

Closes #19 — zoom in/out on click, plus a pop when the count changes
Closes #20 — reset button with a confirmation dialog
Closes #21 — responsive layout for phones

## Notes
- Reset does NOT write to `count_histories`. Increment does.
- Desktop rendering is unchanged; all responsive adjustments are below `sm`.