### PR TITLE
#26 連続クリック時のエラーハンドリング（DB書き込み失敗時)

### DIFF
--- a/src/lib/components/HistoryTable.svelte
+++ b/src/lib/components/HistoryTable.svelte
@@ -9,9 +9,10 @@
 
 	type Props = {
 		history: HistoryEntry[];
+		startIndex?: number;
 	};
 
-	let { history }: Props = $props();
+	let { history, startIndex = 0 }: Props = $props();
 </script>
 
 <div class="overflow-x-auto rounded-lg border border-border bg-surface">
@@ -26,7 +27,7 @@
 		<tbody>
 			{#each history as entry, i (entry.id)}
 				<tr class="border-t border-border-soft transition hover:bg-row-hover">
-					<td class="px-6 py-3 text-dim">{i + 1}</td>
+					<td class="px-6 py-3 text-dim">{startIndex + i + 1}</td>
 					<td class="px-6 py-3 font-medium text-ink">{entry.count}</td>
 					<td class="px-6 py-3 text-muted">{formatDateJP(entry.clicked_at)}</td>
 				</tr>

--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	type Props = {
+		page: number;
+		totalPages: number;
+	};
+
+	let { page, totalPages }: Props = $props();
+</script>
+
+{#if totalPages > 1}
+	<nav
+		class="mt-4 flex items-center justify-center gap-4 font-['Noto_Sans_JP'] text-sm text-ink"
+		aria-label="ページネーション"
+	>
+		{#if page > 1}
+			<a
+				href={resolve(`/history?page=${page - 1}`)}
+				class="rounded-lg border border-border px-4 py-2 text-ink transition hover:bg-row-hover"
+			>
+				← 前へ
+			</a>
+		{:else}
+			<span class="rounded-lg border border-border-soft px-4 py-2 text-dim">← 前へ</span>
+		{/if}
+
+		<span class="text-muted">{page} / {totalPages}</span>
+
+		{#if page < totalPages}
+			<a
+				href={resolve(`/history?page=${page + 1}`)}
+				class="rounded-lg border border-border px-4 py-2 text-ink transition hover:bg-row-hover"
+			>
+				次へ →
+			</a>
+		{:else}
+			<span class="rounded-lg border border-border-soft px-4 py-2 text-dim">次へ →</span>
+		{/if}
+	</nav>
+{/if}

--- a/src/lib/components/ResetButton.svelte
+++ b/src/lib/components/ResetButton.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 
+	let { onReset }: { onReset: (count: number) => void } = $props();
+
 	let dialog: HTMLDialogElement | undefined;
 	let resetError = $state<string | null>(null);
 </script>
@@ -42,14 +44,14 @@
 			action="?/reset"
 			use:enhance={() => {
 				resetError = null;
-				return async ({ result, update }) => {
-					if (result.type === 'failure') {
+				return async ({ result }) => {
+					if (result.type === 'success') {
+						onReset((result.data as { count: number }).count);
+						dialog?.close();
+					} else if (result.type === 'failure') {
 						resetError =
 							(result.data as { error?: string } | undefined)?.error ??
 							'Reset failed. Please try again.';
-					} else {
-						await update();
-						dialog?.close();
 					}
 				};
 			}}

--- a/src/lib/components/ResetButton.svelte
+++ b/src/lib/components/ResetButton.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from '$app/forms';
 
 	let dialog: HTMLDialogElement | undefined;
+	let resetError = $state<string | null>(null);
 </script>
 
 <button
@@ -23,6 +24,10 @@
 		カウントを 0 に戻しますか？
 	</p>
 
+	{#if resetError}
+		<p class="mt-2 text-sm text-red-600">{resetError}</p>
+	{/if}
+
 	<div class="mt-6 flex justify-end gap-3">
 		<button
 			type="button"
@@ -36,8 +41,17 @@
 			method="POST"
 			action="?/reset"
 			use:enhance={() => {
-				// Dismiss straight away; enhance still applies the result.
-				dialog?.close();
+				resetError = null;
+				return async ({ result, update }) => {
+					if (result.type === 'failure') {
+						resetError =
+							(result.data as { error?: string } | undefined)?.error ??
+							'Reset failed. Please try again.';
+					} else {
+						await update();
+						dialog?.close();
+					}
+				};
 			}}
 		>
 			<button

--- a/src/lib/server/counter.ts
+++ b/src/lib/server/counter.ts
@@ -26,53 +26,108 @@ function toCountHistory(row: Record<string, unknown>): CountHistory {
 }
 
 export async function ensureCounterTable() {
-	await db.execute(
-		`
-    CREATE TABLE IF NOT EXISTS counters (
-      id INTEGER PRIMARY KEY CHECK (id = 1),
-      value INTEGER NOT NULL DEFAULT 0,
-	  updated_at TEXT DEFAULT (DATETIME('now'))
-    )
-    `
-	);
-	await db.execute(`INSERT OR IGNORE INTO counters (id, value) VALUES (1, 0)`);
+	try {
+		await db.execute(`
+			CREATE TABLE IF NOT EXISTS counters (
+				id INTEGER PRIMARY KEY CHECK (id = 1),
+				value INTEGER NOT NULL DEFAULT 0,
+				updated_at TEXT DEFAULT (DATETIME('now'))
+			)
+		`);
+		await db.execute(`INSERT OR IGNORE INTO counters (id, value) VALUES (1, 0)`);
+	} catch (error) {
+		throw new Error(
+			`Failed to initialise counters table: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error }
+		);
+	}
 }
 
 export async function ensureCountHistoryTable() {
-	await db.execute(
-		`
-    CREATE TABLE IF NOT EXISTS count_histories (
-        id         INTEGER PRIMARY KEY AUTOINCREMENT,
-        counter_id INTEGER NOT NULL REFERENCES counters(id),
-        count      INTEGER NOT NULL,
-        clicked_at TEXT DEFAULT (DATETIME('now'))
-    );
-    `
-	);
+	try {
+		await db.execute(`
+			CREATE TABLE IF NOT EXISTS count_histories (
+				id         INTEGER PRIMARY KEY AUTOINCREMENT,
+				counter_id INTEGER NOT NULL REFERENCES counters(id),
+				count      INTEGER NOT NULL,
+				clicked_at TEXT DEFAULT (DATETIME('now'))
+			)
+		`);
+	} catch (error) {
+		throw new Error(
+			`Failed to initialise count_histories table: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error }
+		);
+	}
 }
 
 export async function getCounter(): Promise<number> {
-	const result = await db.execute('SELECT value FROM counters WHERE id = 1');
-	const value = result.rows[0]?.value ?? 0;
-	return typeof value === 'number' ? value : Number(value);
+	try {
+		const result = await db.execute('SELECT value FROM counters WHERE id = 1');
+		const value = result.rows[0]?.value ?? 0;
+		return typeof value === 'number' ? value : Number(value);
+	} catch (error) {
+		throw new Error(
+			`Failed to retrieve counter: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error }
+		);
+	}
 }
 
 export async function incrementCounter(): Promise<number> {
-	await db.execute('UPDATE counters SET value = value + 1 WHERE id = 1');
-	const newValue = await getCounter();
-	await db.execute({
-		sql: 'INSERT INTO count_histories (counter_id, count) VALUES (?, ?)',
-		args: [1, newValue]
-	});
-	return newValue;
+	const tx = await db.transaction('write');
+	try {
+		await tx.execute(
+			"UPDATE counters SET value = value + 1, updated_at = DATETIME('now') WHERE id = 1"
+		);
+
+		const result = await tx.execute('SELECT value FROM counters WHERE id = 1');
+		const raw = result.rows[0]?.value ?? 0;
+		const newValue = typeof raw === 'number' ? raw : Number(raw);
+
+		await tx.execute({
+			sql: 'INSERT INTO count_histories (counter_id, count) VALUES (?, ?)',
+			args: [1, newValue]
+		});
+
+		await tx.commit();
+		return newValue;
+	} catch (error) {
+		await tx.rollback().catch((rollbackErr) => {
+			console.error('Rollback failed:', rollbackErr);
+		});
+		throw new Error(
+			`Failed to increment counter: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error }
+		);
+	}
 }
 
 export async function resetCounter(): Promise<number> {
-	await db.execute('UPDATE counters SET value = 0 WHERE id = 1');
-	return getCounter();
+	const tx = await db.transaction('write');
+	try {
+		await tx.execute("UPDATE counters SET value = 0, updated_at = DATETIME('now') WHERE id = 1");
+		await tx.commit();
+		return await getCounter();
+	} catch (error) {
+		await tx.rollback().catch((rollbackErr) => {
+			console.error('Rollback failed:', rollbackErr);
+		});
+		throw new Error(
+			`Failed to reset counter: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error }
+		);
+	}
 }
 
 export async function getCountHistory(): Promise<CountHistory[]> {
-	const result = await db.execute('SELECT * FROM count_histories ORDER BY clicked_at DESC');
-	return result.rows.map((row) => toCountHistory(row as Record<string, unknown>));
+	try {
+		const result = await db.execute('SELECT * FROM count_histories ORDER BY clicked_at DESC');
+		return result.rows.map((row) => toCountHistory(row as Record<string, unknown>));
+	} catch (error) {
+		throw new Error(
+			`Failed to retrieve count history: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error }
+		);
+	}
 }

--- a/src/lib/server/counter.ts
+++ b/src/lib/server/counter.ts
@@ -75,27 +75,18 @@ export async function getCounter(): Promise<number> {
 }
 
 export async function incrementCounter(): Promise<number> {
-	const tx = await db.transaction('write');
 	try {
-		await tx.execute(
-			"UPDATE counters SET value = value + 1, updated_at = DATETIME('now') WHERE id = 1"
+		const [updateResult] = await db.batch(
+			[
+				"UPDATE counters SET value = value + 1, updated_at = DATETIME('now') WHERE id = 1 RETURNING value",
+				'INSERT INTO count_histories (counter_id, count) VALUES (1, (SELECT value FROM counters WHERE id = 1))'
+			],
+			'write'
 		);
 
-		const result = await tx.execute('SELECT value FROM counters WHERE id = 1');
-		const raw = result.rows[0]?.value ?? 0;
-		const newValue = typeof raw === 'number' ? raw : Number(raw);
-
-		await tx.execute({
-			sql: 'INSERT INTO count_histories (counter_id, count) VALUES (?, ?)',
-			args: [1, newValue]
-		});
-
-		await tx.commit();
-		return newValue;
+		const raw = updateResult.rows[0]?.value ?? 0;
+		return typeof raw === 'number' ? raw : Number(raw);
 	} catch (error) {
-		await tx.rollback().catch((rollbackErr) => {
-			console.error('Rollback failed:', rollbackErr);
-		});
 		throw new Error(
 			`Failed to increment counter: ${error instanceof Error ? error.message : String(error)}`,
 			{ cause: error }
@@ -104,15 +95,13 @@ export async function incrementCounter(): Promise<number> {
 }
 
 export async function resetCounter(): Promise<number> {
-	const tx = await db.transaction('write');
 	try {
-		await tx.execute("UPDATE counters SET value = 0, updated_at = DATETIME('now') WHERE id = 1");
-		await tx.commit();
-		return await getCounter();
+		const result = await db.execute(
+			"UPDATE counters SET value = 0, updated_at = DATETIME('now') WHERE id = 1 RETURNING value"
+		);
+		const raw = result.rows[0]?.value ?? 0;
+		return typeof raw === 'number' ? raw : Number(raw);
 	} catch (error) {
-		await tx.rollback().catch((rollbackErr) => {
-			console.error('Rollback failed:', rollbackErr);
-		});
 		throw new Error(
 			`Failed to reset counter: ${error instanceof Error ? error.message : String(error)}`,
 			{ cause: error }
@@ -120,13 +109,32 @@ export async function resetCounter(): Promise<number> {
 	}
 }
 
-export async function getCountHistory(): Promise<CountHistory[]> {
+export async function getCountHistory({
+	limit = 50,
+	offset = 0
+}: { limit?: number; offset?: number } = {}): Promise<CountHistory[]> {
 	try {
-		const result = await db.execute('SELECT * FROM count_histories ORDER BY clicked_at DESC');
+		const result = await db.execute({
+			sql: 'SELECT * FROM count_histories ORDER BY clicked_at DESC LIMIT ? OFFSET ?',
+			args: [limit, offset]
+		});
 		return result.rows.map((row) => toCountHistory(row as Record<string, unknown>));
 	} catch (error) {
 		throw new Error(
 			`Failed to retrieve count history: ${error instanceof Error ? error.message : String(error)}`,
+			{ cause: error }
+		);
+	}
+}
+
+export async function getCountHistoryTotal(): Promise<number> {
+	try {
+		const result = await db.execute('SELECT COUNT(*) as total FROM count_histories');
+		const value = result.rows[0]?.total ?? 0;
+		return typeof value === 'number' ? value : Number(value);
+	} catch (error) {
+		throw new Error(
+			`Failed to retrieve count history total: ${error instanceof Error ? error.message : String(error)}`,
 			{ cause: error }
 		);
 	}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,4 +1,5 @@
 import type { PageServerLoad, Actions } from './$types';
+import { error, fail } from '@sveltejs/kit';
 import {
 	ensureCounterTable,
 	ensureCountHistoryTable,
@@ -8,18 +9,33 @@ import {
 } from '$lib/server/counter';
 
 export const load: PageServerLoad = async () => {
-	await ensureCounterTable();
-	await ensureCountHistoryTable();
-	return { count: await getCounter() };
+	try {
+		await ensureCounterTable();
+		await ensureCountHistoryTable();
+		return { count: await getCounter() };
+	} catch (e) {
+		console.error('Failed to load counter:', e);
+		error(500, 'Could not load counter. Please try again later.');
+	}
 };
 
 export const actions: Actions = {
 	increment: async () => {
-		const count = await incrementCounter();
-		return { count };
+		try {
+			const count = await incrementCounter();
+			return { count };
+		} catch (e) {
+			console.error('Failed to increment counter:', e);
+			return fail(500, { error: 'Increment failed. Please try again.' });
+		}
 	},
 	reset: async () => {
-		const count = await resetCounter();
-		return { count };
+		try {
+			const count = await resetCounter();
+			return { count };
+		} catch (e) {
+			console.error('Failed to reset counter:', e);
+			return fail(500, { error: 'Reset failed. Please try again.' });
+		}
 	}
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,8 @@
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
+
+	let incrementError = $state<string | null>(null);
 </script>
 
 <div class="flex min-h-screen flex-col items-center bg-bg">
@@ -35,9 +37,27 @@
 		>
 			<CountDisplay count={data.count} />
 			<div class="flex flex-col items-center gap-5 sm:gap-6">
-				<form method="POST" action="?/increment" use:enhance>
+				<form
+					method="POST"
+					action="?/increment"
+					use:enhance={() => {
+						incrementError = null;
+						return async ({ result, update }) => {
+							if (result.type === 'failure') {
+								incrementError =
+									(result.data as { error?: string } | undefined)?.error ??
+									'Increment failed. Please try again.';
+							} else {
+								await update();
+							}
+						};
+					}}
+				>
 					<CountButton />
 				</form>
+				{#if incrementError}
+					<p class="text-sm text-red-600">{incrementError}</p>
+				{/if}
 				<ResetButton />
 			</div>
 			<span

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,18 +4,21 @@
 	import ResetButton from '$lib/components/ResetButton.svelte';
 	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
 	import { enhance } from '$app/forms';
-	import { resolveRoute } from '$app/paths';
+	import { resolve } from '$app/paths';
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
 
+	let count = $derived(data.count);
+
+	let incrementPending = $state(false);
 	let incrementError = $state<string | null>(null);
 </script>
 
 <div class="flex min-h-screen flex-col items-center bg-bg">
 	<header class="grid w-full grid-cols-3 items-center py-10">
 		<a
-			href={resolveRoute('/history')}
+			href={resolve('/history')}
 			class="text-md justify-self-start pl-6 text-ink/60 transition hover:text-ink"
 		>
 			歴史
@@ -35,30 +38,38 @@
              p-8 shadow-2xl shadow-accent/30
              sm:gap-10 sm:p-12 md:p-16"
 		>
-			<CountDisplay count={data.count} />
+			<CountDisplay {count} />
 			<div class="flex flex-col items-center gap-5 sm:gap-6">
 				<form
 					method="POST"
 					action="?/increment"
-					use:enhance={() => {
+					use:enhance={({ cancel }) => {
+						if (incrementPending) {
+							cancel();
+							return;
+						}
+						incrementPending = true;
 						incrementError = null;
-						return async ({ result, update }) => {
-							if (result.type === 'failure') {
+						return async ({ result }) => {
+							incrementPending = false;
+							if (result.type === 'success') {
+								count = (result.data as { count: number }).count;
+							} else if (result.type === 'failure') {
 								incrementError =
 									(result.data as { error?: string } | undefined)?.error ??
 									'Increment failed. Please try again.';
-							} else {
-								await update();
 							}
 						};
 					}}
 				>
-					<CountButton />
+					<fieldset disabled={incrementPending} class="contents">
+						<CountButton />
+					</fieldset>
 				</form>
 				{#if incrementError}
 					<p class="text-sm text-red-600">{incrementError}</p>
 				{/if}
-				<ResetButton />
+				<ResetButton onReset={(newCount) => (count = newCount)} />
 			</div>
 			<span
 				class="text-center font-['Noto_Sans_JP'] text-[10px] tracking-[0.2em] text-accent/70 sm:tracking-[0.3em]"

--- a/src/routes/history/+page.server.ts
+++ b/src/routes/history/+page.server.ts
@@ -1,12 +1,28 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
-import { ensureCountHistoryTable, getCountHistory } from '$lib/server/counter';
+import {
+	ensureCountHistoryTable,
+	getCountHistory,
+	getCountHistoryTotal
+} from '$lib/server/counter';
 
-export const load: PageServerLoad = async () => {
+const PAGE_SIZE = 15;
+
+export const load: PageServerLoad = async ({ url }) => {
 	try {
 		await ensureCountHistoryTable();
-		const history = await getCountHistory();
-		return { history };
+
+		const total = await getCountHistoryTotal();
+		const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+		const requestedPage = Number(url.searchParams.get('page'));
+		const page = Number.isInteger(requestedPage)
+			? Math.min(Math.max(requestedPage, 1), totalPages)
+			: 1;
+
+		const history = await getCountHistory({ limit: PAGE_SIZE, offset: (page - 1) * PAGE_SIZE });
+
+		return { history, page, totalPages, total, pageSize: PAGE_SIZE };
 	} catch (e) {
 		console.error('Failed to load history:', e);
 		error(500, 'Could not load history. Please try again later.');

--- a/src/routes/history/+page.server.ts
+++ b/src/routes/history/+page.server.ts
@@ -1,8 +1,14 @@
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 import { ensureCountHistoryTable, getCountHistory } from '$lib/server/counter';
 
 export const load: PageServerLoad = async () => {
-	await ensureCountHistoryTable();
-	const history = await getCountHistory();
-	return { history };
+	try {
+		await ensureCountHistoryTable();
+		const history = await getCountHistory();
+		return { history };
+	} catch (e) {
+		console.error('Failed to load history:', e);
+		error(500, 'Could not load history. Please try again later.');
+	}
 };

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import type { PageProps } from './$types';
-	import { resolveRoute } from '$app/paths';
+	import { resolve } from '$app/paths';
 	import HistoryTable from '$lib/components/HistoryTable.svelte';
+	import Pagination from '$lib/components/Pagination.svelte';
 
 	let { data }: PageProps = $props();
 </script>
@@ -9,7 +10,7 @@
 <div class="flex min-h-screen flex-col bg-bg">
 	<header class="grid w-full grid-cols-3 items-center py-10">
 		<a
-			href={resolveRoute('/')}
+			href={resolve('/')}
 			class="justify-self-start pl-6 text-sm text-ink/60 transition hover:text-ink"
 		>
 			← 後ろ
@@ -23,6 +24,7 @@
 	</header>
 
 	<main class="mx-auto w-full max-w-2xl px-4">
-		<HistoryTable history={data.history} />
+		<HistoryTable history={data.history} startIndex={(data.page - 1) * data.pageSize} />
+		<Pagination page={data.page} totalPages={data.totalPages} />
 	</main>
 </div>


### PR DESCRIPTION
#26 連続クリック時のエラーハンドリング（DB書き込み失敗時)

このイシューを完了しました。

- DB書き込み失敗時にtry/catchでエラーを捕まえる
- エラー時にユーザーへ分かりやすいメッセージを表示
- 連続クリックしてもアプリが落ちないことを確認

ご確認をお願いいたします。